### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/bookkeeper/LocalStore.java
+++ b/src/main/java/org/apache/sling/distribution/journal/bookkeeper/LocalStore.java
@@ -88,7 +88,7 @@ public class LocalStore {
         } else {
             serviceResolver.create(parent, storeId, map);
         }
-        LOG.debug(String.format("Stored data %s for storeId %s", map.toString(), storeId));
+        LOG.debug(String.format("Stored data %s for storeId %s", map, storeId));
     }
 
     public <T> T load(String key, Class<T> clazz) {


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:-568776420 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (1)
